### PR TITLE
Create output directory before saving predictions

### DIFF
--- a/src/predict_image.py
+++ b/src/predict_image.py
@@ -12,6 +12,7 @@ import cv2
 model_path = "models/resnet18_skin_weighted_earlystop.pt"
 input_folder = "test_images"
 output_folder = "outputs"
+os.makedirs(output_folder, exist_ok=True)
 max_images = 20
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 class_names = ["benign", "malignant"]


### PR DESCRIPTION
## Summary
- Ensure `src/predict_image.py` creates the output folder before saving Grad-CAM images

## Testing
- `timeout 30 pytest -q` (fails: FileNotFoundError: [Errno 2] No such file or directory: 'data/train.csv')

